### PR TITLE
AI修复权重错误问题

### DIFF
--- a/import_xnalara_model.py
+++ b/import_xnalara_model.py
@@ -588,7 +588,7 @@ def assignUvs(meshData, faces, uvLayers, vertexColors):
     makeUvs(meshData, faces, uvLayers, vertexColors)
 
 
-def setupMaterialAndRigging(meshObj, meshInfo, armatureObj):
+def setupMaterialAndRigging(meshObj, meshInfo, armatureObj, mergedVertexList):
     """Setting Up Materials and Rigging"""
     flags = xpsData.header.flags if xpsData.header else read_bin_xps.flagsDefault()
     material_creator.makeMaterial(xpsSettings, rootDir, meshObj.data, meshInfo, flags)
@@ -598,7 +598,7 @@ def setupMaterialAndRigging(meshObj, meshInfo, armatureObj):
         setParent(armatureObj, meshObj)
         if armatureObj.mode != 'OBJECT':
             bpy.ops.object.mode_set(mode='OBJECT')
-        makeVertexGroups(meshObj, meshInfo.vertices)
+        makeVertexGroups(meshObj, mergedVertexList)
         makeBoneGroups(armatureObj, meshObj)
 
 
@@ -622,7 +622,7 @@ def importMesh(armatureObj, meshInfo):
     originalFaces = list(faceTransformList(meshInfo.faces))
     faces = createFaces(meshData, vertexDict, mergedVertexList, meshInfo, useSeams)
     assignUvs(meshData, originalFaces, uvLayers, vertexColors)
-    setupMaterialAndRigging(meshObj, meshInfo, armatureObj)
+    setupMaterialAndRigging(meshObj, meshInfo, armatureObj, mergedVertexList)
 
 
     if xpsSettings.importNormals and not hasattr(xpsSettings, 'skipNormals'):


### PR DESCRIPTION
## 问题分析
在 import_xnalara_model.py 中，当启用 joinMeshRips 选项时，顶点会根据坐标和法线进行合并。但代码存在一个关键错误：

1. 顶点合并过程 ： processVertices 函数生成了 vertexDict （原始索引→合并后索引的映射）和 mergedVertexList （合并后的顶点列表）
2. 网格创建 ：使用 mergedVertexList 创建 Blender 网格，所以 Blender 中的顶点索引是合并后的索引
3. 权重分配 ： makeVertexGroups 函数被调用时传入的是 原始 顶点列表 meshInfo.vertices ，导致权重被分配到错误的顶点上 ## 修复方案
修改了两个函数：

1. setupMaterialAndRigging ：添加了 mergedVertexList 参数，并传递给 makeVertexGroups
2. importMesh ：调用 setupMaterialAndRigging 时传入 mergedVertexList 这样权重就会正确地分配到合并后的顶点上，修复了权重结果不正确的问题。

修复涉及的文件：

- import_xnalara_model.py:591 - 修改函数签名
- import_xnalara_model.py:625 - 更新函数调用