### PR TITLE
refactor(xps_panels, xps_toolshelf): 优化操作符创建和注册逻辑

### DIFF
--- a/xps_panels.py
+++ b/xps_panels.py
@@ -91,13 +91,11 @@ class XPSToolsBonesPanel(_XpsPanels, bpy.types.Panel):
         col.label(text='Connect Bones:')
         c = col.column(align=True)
         r = c.row(align=True)
-        r.operator(
-            'xps_tools.bones_connect',
-            text='Connect All').connectBones = True
+        op = r.operator('xps_tools.bones_connect', text='Connect All')
+        op.connectBones = True
         r = c.row(align=True)
-        r.operator(
-            'xps_tools.bones_connect',
-            text='Disconnect All').connectBones = False
+        op = r.operator('xps_tools.bones_connect', text='Disconnect All')
+        op.connectBones = False
         col.label(text='New Rest Pose:')
         c = col.column(align=True)
         r = c.row(align=True)

--- a/xps_toolshelf.py
+++ b/xps_toolshelf.py
@@ -198,3 +198,23 @@ class NewRestPose_Op(bpy.types.Operator):
     def invoke(self, context, event):
         self.action_common(context)
         return {"FINISHED"}
+
+
+def register():
+    bpy.utils.register_class(ArmatureBonesHideByName_Op)
+    bpy.utils.register_class(ArmatureBonesHideByVertexGroup_Op)
+    bpy.utils.register_class(ArmatureBonesShowAll_Op)
+    bpy.utils.register_class(ArmatureBonesRenameToBlender_Op)
+    bpy.utils.register_class(ArmatureBonesRenameToXps_Op)
+    bpy.utils.register_class(ArmatureBonesConnect_Op)
+    bpy.utils.register_class(NewRestPose_Op)
+
+
+def unregister():
+    bpy.utils.unregister_class(ArmatureBonesHideByName_Op)
+    bpy.utils.unregister_class(ArmatureBonesHideByVertexGroup_Op)
+    bpy.utils.unregister_class(ArmatureBonesShowAll_Op)
+    bpy.utils.unregister_class(ArmatureBonesRenameToBlender_Op)
+    bpy.utils.unregister_class(ArmatureBonesRenameToXps_Op)
+    bpy.utils.unregister_class(ArmatureBonesConnect_Op)
+    bpy.utils.unregister_class(NewRestPose_Op)


### PR DESCRIPTION
将分散的操作符属性设置改为先获取实例再赋值，补全工具类的注册/反注册函数